### PR TITLE
Update for java 11, geotools 21.2, and jts 1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,99 +1,113 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.axiomalaska</groupId>
-	<artifactId>polyline-encoder</artifactId>
-	<version>0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
 
-	<name>polyline-encoder</name>
+    <groupId>com.axiomalaska</groupId>
+    <artifactId>polyline-encoder</artifactId>
+    <version>0.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<licenses>
-		<license>
-			<name>GNU Lesser General Public License</name>
-			<url>http://www.gnu.org/licenses/lgpl.html</url>
-		</license>
-	</licenses>
-	
-	<properties>
-	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	    <geotools.version>2.7-M3</geotools.version>
-	</properties>
+    <name>polyline-encoder</name>
 
-	<distributionManagement>
-	    <repository>
-	        <id>axiom_public_releases</id>
-	        <name>Axiom Releases</name>
-	        <uniqueVersion>false</uniqueVersion>
-	        <url>http://nexus.axiomalaska.com/nexus/content/repositories/public-releases</url>
-	    </repository>
-	    <snapshotRepository>
-	        <id>axiom_public_snapshots</id>
-	        <name>Axiom Snapshots</name>
-	        <uniqueVersion>false</uniqueVersion>
-	        <url>http://nexus.axiomalaska.com/nexus/content/repositories/public-snapshots</url>
-	    </snapshotRepository>
-	</distributionManagement>
-	
-	<build>
-	    <plugins>
-	        <plugin>
-	            <artifactId>maven-compiler-plugin</artifactId>
-	            <version>2.1</version>
-	            <configuration>
-	                <target>1.5</target>
-	                <source>1.5</source>
-	            </configuration>
-	        </plugin>
-		    <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
-		        <artifactId>maven-source-plugin</artifactId>
-		        <version>2.1.2</version>
-		        <executions>
-		            <execution>
-		                <goals>
-		                    <goal>jar</goal>
-		                    <goal>test-jar</goal>
-		                </goals>
-		            </execution>
-		        </executions>
-		    </plugin>
-		    <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
-		        <artifactId>maven-jar-plugin</artifactId>
-		        <version>2.3.1</version>
-		        <executions>
-		            <execution>
-		                <goals>
-		                    <goal>test-jar</goal>
-		                </goals>
-		            </execution>
-		        </executions>
-		    </plugin>	        
-	    </plugins>
-	</build>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://www.gnu.org/licenses/lgpl.html</url>
+        </license>
+    </licenses>
 
-	<dependencies>
-	    <dependency>
-	        <groupId>com.vividsolutions</groupId>
-	        <artifactId>jts</artifactId>
-	        <version>1.11</version>
-	    </dependency>
-	    <dependency>
-	        <groupId>org.geotools</groupId>
-	        <artifactId>gt-grid</artifactId>
-	        <version>${geotools.version}</version>
-	    </dependency>
-	    <dependency>
-	        <groupId>org.geotools</groupId>
-	        <artifactId>gt-epsg-hsql</artifactId>
-	        <version>${geotools.version}</version>
-	    </dependency>
-	    <dependency>
-	        <groupId>junit</groupId>
-	        <artifactId>junit</artifactId>
-	        <version>3.8.1</version>
-	        <scope>test</scope>
-	    </dependency>
-	</dependencies>
+    <properties>
+        <geotools.version>21.2</geotools.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>axiom_public_releases</id>
+            <name>Axiom Releases</name>
+            <uniqueVersion>false</uniqueVersion>
+            <url>http://nexus.axiomalaska.com/nexus/content/repositories/public-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>axiom_public_snapshots</id>
+            <name>Axiom Snapshots</name>
+            <uniqueVersion>false</uniqueVersion>
+            <url>http://nexus.axiomalaska.com/nexus/content/repositories/public-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <!-- For Java 11 Modules, specify a module name. Do not create module-info.java until all
+                                 our dependencies specify a module name. -->
+                            <Automatic-Module-Name>com.axiomalaska.polylineencoder</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>osgeo</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>https://download.osgeo.org/webdav/geotools/</url>
+        </repository>
+    </repositories>
+
 </project>

--- a/src/main/java/com/axiomalaska/polylineencoder/PolylineEncoder.java
+++ b/src/main/java/com/axiomalaska/polylineencoder/PolylineEncoder.java
@@ -4,16 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.geom.PrecisionModel;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import com.vividsolutions.jts.operation.distance.DistanceOp;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.operation.distance.DistanceOp;
 
 /**
  * Class to apply the Google polyline encoding algorithm to JTS geometries (LineStrings and Polygons). 

--- a/src/main/java/com/axiomalaska/polylineencoder/Reprojector.java
+++ b/src/main/java/com/axiomalaska/polylineencoder/Reprojector.java
@@ -12,16 +12,16 @@ import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 
 import com.axiomalaska.polylineencoder.UnsupportedGeometryTypeException;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
 
 public class Reprojector {   
     public static Geometry reproject( String wkt, int fromSrid, int toSrid) throws MismatchedDimensionException, NoSuchAuthorityCodeException, FactoryException, UnsupportedGeometryTypeException, TransformException, ParseException{

--- a/src/main/java/com/axiomalaska/polylineencoder/WktUtil.java
+++ b/src/main/java/com/axiomalaska/polylineencoder/WktUtil.java
@@ -1,10 +1,10 @@
 package com.axiomalaska.polylineencoder;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.PrecisionModel;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 public class WktUtil {
     public static Geometry wktToGeom( String wkt ) throws ParseException{ 

--- a/src/test/java/com/axiomalaska/polylineEncoder/PolylineEncoderTest.java
+++ b/src/test/java/com/axiomalaska/polylineEncoder/PolylineEncoderTest.java
@@ -7,13 +7,13 @@ import java.io.IOException;
 import com.axiomalaska.polylineencoder.EncodedPolyline;
 import com.axiomalaska.polylineencoder.PolylineEncoder;
 import com.axiomalaska.polylineencoder.UnsupportedGeometryTypeException;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.geom.PrecisionModel;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 import junit.framework.TestCase;
 


### PR DESCRIPTION
Hello, we are using your polyline encoder library in software that we just migrated to build under Java 11. As part of that migration we also updated to Geotools 21.2 and (transitively) JTS 1.16. This pull request allows the library to build under Java 11.

Unfortunately I triggered a bunch of whitespace changes in the POM. If you're interested in merging these changes and would prefer to avoid the whitespace changes I can reformat the POM.